### PR TITLE
[WIP]Fields for実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 - has_many :comments
 - has_many :likes
 - has_many :liked_products, through: :likes, source: :product
+- has_many :buyed_products, foreign_key: "buyer_id", class_name: "Product"
+- has_many :saling_products, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Product"
+- has_many :sold_products, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Product"
 
 
 ## credit_infosテーブル
@@ -79,11 +82,12 @@
 
 |Column|Type|Options|
 |------|----|———|
-|image|string|null: false|
 |title|text|null:false, index:true|
 |text|text| |
 |price|integer|null: false|
 |user_id|references|foreign_key:true|
+|buyer_id|integer||
+|saler_id|integer||
 
 ### Association
 - belongs_to :user
@@ -93,9 +97,23 @@
 - belongs_to :freight
 - belongs_to :root_area
 - belongs_to :day
+- belongs_to :saler, class_name: "User"
+- belongs_to :buyer, class_name: "User"
 - has_many :comments
 - has_many :likes
 - has_many :liked_users, through: :likes, source: :user
+- has_many :images, inverse_of: :product, dependent: :destroy
+- accepts_nested_attributes_for :images
+
+
+## imagesテーブル
+|Column|Type|Options|
+|------|----|———|
+|image_url|string|null: false|
+|product_id|references|foreign_key:true|
+
+### Association
+- belongs_to :product, inverse_of: :images
 
 
 ## commentsテーブル

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,7 +34,7 @@ class ProductsController < ApplicationController
 
   def buyer_show
     @product = Product.find(params[:id])
-    # @image = Image.find(params[:product_id])
+    # @image = Image.find(params[:product_id])　現在詳細画面で画像を表示しないようにしています。（エラーが出るため確認中）
   end
   
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   def index
-    @product = Product.all
+    @product = Product.all.includes(:images)
     @parents = Category.all.order("id ASC").limit(13)
   end
 
@@ -11,8 +11,7 @@ class ProductsController < ApplicationController
   end
 
   def create
-    @product = Product.create(product_params)
-    binding.pry
+    @product = Product.new(product_params)
     if @product.save
       redirect_to root_path
     else 
@@ -35,13 +34,14 @@ class ProductsController < ApplicationController
 
   def buyer_show
     @product = Product.find(params[:id])
+    # @image = Image.find(params[:product_id])
   end
   
   private
   def product_params
     params.require(:product).permit(
-      :title, :text, :price,
-      images_attributes: {image: []}
+      :title, :text, :price, :saler_id,
+      images_attributes: [:image_url]
     )
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,11 +7,12 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
+    @product.images.build
   end
 
   def create
     @product = Product.create(product_params)
-    # binding.pry
+    binding.pry
     if @product.save
       redirect_to root_path
     else 
@@ -38,6 +39,9 @@ class ProductsController < ApplicationController
   
   private
   def product_params
-    params.require(:product).permit(:title, :image, :text, :price)
+    params.require(:product).permit(
+      :title, :text, :price,
+      images_attributes: {image: []}
+    )
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,4 @@
+class Image < ApplicationRecord
+  belongs_to :product, inverse_of: :images
+  mount_uploader :image_url, ImageUploader
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,9 +1,11 @@
 class Product < ApplicationRecord
-  mount_uploader :image, ImageUploader
   
   belongs_to :user, foreign_key: 'user_id'
   belongs_to :category
   
   belongs_to :saler, class_name: "User"
   belongs_to :buyer, class_name: "User"
+
+  has_many :images, inverse_of: :product, dependent: :destroy
+  accepts_nested_attributes_for :images
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,10 +1,10 @@
 class Product < ApplicationRecord
   
-  belongs_to :user, foreign_key: 'user_id'
-  belongs_to :category
+  # belongs_to :user, foreign_key: 'user_id'
+  # belongs_to :category
   
   belongs_to :saler, class_name: "User"
-  belongs_to :buyer, class_name: "User"
+  belongs_to :buyer, class_name: "User", optional: true
 
   has_many :images, inverse_of: :product, dependent: :destroy
   accepts_nested_attributes_for :images

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,6 @@
 class Product < ApplicationRecord
   
-  # belongs_to :user, foreign_key: 'user_id'
-  # belongs_to :category
+  # belongs_to :category　カテゴリー実装じにコメントアウト外す
   
   belongs_to :saler, class_name: "User"
   belongs_to :buyer, class_name: "User", optional: true

--- a/app/views/products/buyer_show.html.haml
+++ b/app/views/products/buyer_show.html.haml
@@ -19,7 +19,7 @@
             = link_to "マイページ", user_path(current_user.id), class: "header__box__bottom__right--my_page--link"
 
 %h2= @product.title
-= image_tag(@product.image.url, class: "product_image")
+-# = image_tag(@image.image_url.url, class: "product_image")
 %li= "出品者: #{@product.saler.nickname}"
 %li= "¥ #{@product.price} (税込)"
 

--- a/app/views/products/buyer_show.html.haml
+++ b/app/views/products/buyer_show.html.haml
@@ -19,7 +19,7 @@
             = link_to "マイページ", user_path(current_user.id), class: "header__box__bottom__right--my_page--link"
 
 %h2= @product.title
--# = image_tag(@image.image_url.url, class: "product_image")
+-# = image_tag(@image.image_url.url, class: "product_image")　現在詳細画面で画像を表示しないようにしています。（エラーが出るため確認中）
 %li= "出品者: #{@product.saler.nickname}"
 %li= "¥ #{@product.price} (税込)"
 

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -37,8 +37,6 @@
     %p.product
       = p.title
       = link_to p.title ,buyer_show_product_path(p.id)
-      -# = link_to image_tag(p.image_urls, class: "product_image"),buyer_show_product_path(p.id)
-      -# = image_tag　p.@image.image_url
       - p.images.each do |image|
         = image_tag(image.image_url.url, class: "product_image")
       = p.text

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -36,10 +36,14 @@
   - @product.each do |p|
     %p.product
       = p.title
+      = link_to p.title ,buyer_show_product_path(p.id)
       -# = link_to image_tag(p.image_urls, class: "product_image"),buyer_show_product_path(p.id)
-      -# = image_tag　p.image_url
+      -# = image_tag　p.@image.image_url
+      - p.images.each do |image|
+        = image_tag(image.image_url.url, class: "product_image")
       = p.text
       = p.price
     .line ------------------------------
+  
 
   = link_to "出品", new_product_path, class: 'new_exhibit'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -36,7 +36,8 @@
   - @product.each do |p|
     %p.product
       = p.title
-      = link_to image_tag(p.image.url, class: "product_image"),buyer_show_product_path(p.id)
+      -# = link_to image_tag(p.image_urls, class: "product_image"),buyer_show_product_path(p.id)
+      -# = image_tag　p.image_url
       = p.text
       = p.price
     .line ------------------------------

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -3,7 +3,7 @@
 = form_for @product do |f|
   %h4 出品画像
   = f.fields_for :images do |c|
-    = c.file_field :image_url, multiple: true
+    = c.file_field :image_url
   %br/
   %h4 商品名
   = f.text_field :title, placeholder: '商品名（必須 40文字まで）'
@@ -14,7 +14,8 @@
   %h4 価格
   = f.number_field :price, placeholder: '例) 300'
   %br/
-  = f.hidden_field :saler_id, current_user.id
+  = f.hidden_field :saler_id, value: current_user.id
+  %br/ 
   = f.submit :"出品する"
 
   = link_to 'もどる', :back

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -2,7 +2,8 @@
 %h1  出品フォーム
 = form_for @product do |f|
   %h4 出品画像
-  = f.file_field :image
+  = f.fields_for :images do |c|
+    = c.file_field :image_url, multiple: true
   %br/
   %h4 商品名
   = f.text_field :title, placeholder: '商品名（必須 40文字まで）'
@@ -13,6 +14,7 @@
   %h4 価格
   = f.number_field :price, placeholder: '例) 300'
   %br/
+  = f.hidden_field :saler_id, current_user.id
   = f.submit :"出品する"
 
   = link_to 'もどる', :back

--- a/db/migrate/20191104030217_create_images.rb
+++ b/db/migrate/20191104030217_create_images.rb
@@ -1,0 +1,10 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :image_url, null: false
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_02_083313) do
+ActiveRecord::Schema.define(version: 2019_11_04_030217) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 2019_11_02_083313) do
     t.datetime "updated_at", null: false
     t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
+  end
+
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "image_url", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_images_on_product_id"
   end
 
   create_table "products", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -54,4 +62,5 @@ ActiveRecord::Schema.define(version: 2019_11_02_083313) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "images", "products"
 end

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  image_url: MyString
+
+two:
+  image_url: MyString

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#what
・商品出品時にユーザーにsalerとしての情報を持たせる（DBにsaler_idを追加）、アソシエーションを組む
・出品時に複数画像をアップできるようにnew.html.hamlの画像フォームをfield_forに変更（DBのproductカラムからimageを削除、新たにimagesテーブルを作成）
現在は画像1枚しか添付できないが、今後JAVAscriotを使用し2枚目以降も添付できるようにする予定。
また、buyer_idカラムを作成してアソシエーションを組んでいるため、購入機能実装時にはbuyer_idを利用してください。
→product.rbでuser_idのアソシエーションを組んでいましたが、上記実装に伴い削除しました。


#why
出品時に出品者情報を持たせることによりユーザーの動作を区別するため
